### PR TITLE
Improve [CI/CD] GitHub Actions workflow for test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [19.x, 20.x]
+        node-version: [19.x, 20.x, 21.x, 22.x, 23.x, 24.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- [+] chore(coverage.yml): update node-version matrix to include additional versions 21.x, 22.x, 23.x, and 24.x