### PR TITLE
Enhance [CI/CD] 🧪 Test Coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,11 +14,11 @@ jobs:
           # Note: Some operating systems are not supported due to poor compatibility with Coveralls
           [
             ubuntu-latest,
-            ubuntu-24.04,
+            # ubuntu-24.04, is disabled because ubuntu-latest is equivalent to ubuntu-24.04
             ubuntu-22.04,
             windows-latest,
             windows-2025,
-            windows-2022,
+            # windows-2022, is disabled because windows-latest is equivalent to windows-2022
             macos-latest,
           ]
         node-version: [19.x, 20.x, 21.x, 22.x, 23.x, 24.x]


### PR DESCRIPTION
- [+] chore(coverage.yml): disable ubuntu-24.04 and windows-2022 in CI workflow due to redundancy with latest versions