### PR TITLE
Improve test 1024 dh

### DIFF
--- a/tests/dh_operation.test.ts
+++ b/tests/dh_operation.test.ts
@@ -330,6 +330,13 @@ describe('Safe Prime Generation and Diffie-Hellman Operations', () => {
       const alicePublicKey = dhGeneratePublicKey(p, g, alicePrivateKey);
       const bobPublicKey = dhGeneratePublicKey(p, g, bobPrivateKey);
 
+      // Verify that public keys are not in a small subgroup
+      // For a safe prime, the only small subgroup elements are 1 and p-1
+      expect(alicePublicKey).not.toBe(1n);
+      expect(alicePublicKey).not.toBe(p - 1n);
+      expect(bobPublicKey).not.toBe(1n);
+      expect(bobPublicKey).not.toBe(p - 1n);
+
       // Compute shared secrets
       const aliceSharedSecret = dhComputeSharedSecret(p, bobPublicKey, alicePrivateKey);
       const bobSharedSecret = dhComputeSharedSecret(p, alicePublicKey, bobPrivateKey);


### PR DESCRIPTION
- [+] test(dh_operation.test.ts): add tests to verify public keys are not in a small subgroup for safe prime generation