### PR TITLE
Add support for `randFill` in `randHex`, `randBase64`, and `randBigInt` (sync/async) methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ async function generateRandomValues() {
 - `Crypto.randBytes(size, randFill?)` - Generate random bytes (Node.js: Buffer, Browser: Uint8Array)
 - `Crypto.randChoice(array)` - Pick random array element
 - `Crypto.shuffle(array)` - Shuffle array securely
-- `Crypto.randHex(length)` - Generate random hex string
-- `Crypto.randBase64(length)` - Generate random base64 string
+- `Crypto.randHex(length, randFill?)` - Generate random hex string
+- `Crypto.randBase64(length, randFill?)` - Generate random base64 string
 - `Crypto.randFloat(min, max)` - Generate random float in range
 - `Crypto.randWeighted(items, weights)` - Weighted random selection
 - `Crypto.randNormal(mean, stdDev)` - Normal distribution random
@@ -136,19 +136,19 @@ async function generateRandomValues() {
 - `Crypto.randLattice(dimension?, modulus?)` - Generate lattice-based cryptographically secure random number
 - `Crypto.randPrime(bits?, iterations?, enhanced?)` - Generate cryptographically secure random prime number with optional [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards)-enhanced mode
 - `Crypto.randSafePrime(bits?, iterations?, enhanced?)` - Generate cryptographically secure random safe prime number suitable for [Diffie-Hellman key exchanges](https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)
-- `Crypto.randBigInt(bits?)` - Generate cryptographically secure random bigint with specified bit length
+- `Crypto.randBigInt(bits?, randFill?)` - Generate cryptographically secure random bigint with specified bit length
 - `Crypto.randExponential(lambda?)` - Generate random number with exponential distribution
 
 ### Static Async Methods
 - `Crypto.randAsync()` - Async version of rand()
 - `Crypto.randBytesAsync(size, randFill?)` - Async version of randBytes()
-- `Crypto.randHexAsync(length)` - Async version of randHex()
-- `Crypto.randBase64Async(length)` - Async version of randBase64()
+- `Crypto.randHexAsync(length, randFill?)` - Async version of randHex()
+- `Crypto.randBase64Async(length, randFill?)` - Async version of randBase64()
 - `Crypto.randSeedAsync()` - Async version of randSeed()
 - `Crypto.randVersionAsync()` - Async version of randVersion()
 - `Crypto.randPrimeAsync(bits?, iterations?, enhanced?)` - Async version of randPrime() with optional [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards)-enhanced mode
 - `Crypto.randSafePrimeAsync(bits?, iterations?, enhanced?)` - Async version of randSafePrime() for generating safe primes suitable for [Diffie-Hellman key exchanges](https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)
-- `Crypto.randBigIntAsync(bits?)` - Async version of randBigInt()
+- `Crypto.randBigIntAsync(bits?, randFill?)` - Async version of randBigInt()
 
 > [!TIP]
 > **Benefits of Async Methods**

--- a/src/rand.ts
+++ b/src/rand.ts
@@ -177,12 +177,12 @@ export class Crypto {
      * Generate random hex string.
      * Note: Only available in Node.js environment.
      */
-    static randHex(length: number): string {
+    static randHex(length: number, randFill?: boolean): string {
         if (Crypto.isBrowser()) {
             Crypto.throwBrowserError('randHex');
         }
 
-        const bytes = crypto.randomBytes(Math.ceil(length / 2));
+        const bytes = Crypto.randBytes(Math.ceil(length / 2), randFill);
         return bytes.toString('hex').substring(0, length);
     }
 
@@ -192,14 +192,15 @@ export class Crypto {
      * Note: Only available in Node.js environment.
      * 
      * @param length - Length of the hex string to generate
+     * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
      * @returns Promise that resolves to a random hex string
      */
-    static async randHexAsync(length: number): Promise<string> {
+    static async randHexAsync(length: number, randFill?: boolean): Promise<string> {
         if (Crypto.isBrowser()) {
             Crypto.throwBrowserError('randHexAsync');
         }
 
-        const bytes = await randomBytesAsync!(Math.ceil(length / 2));
+        const bytes = await Crypto.randBytesAsync!(Math.ceil(length / 2), randFill);
         return bytes.toString('hex').substring(0, length);
     }
 
@@ -207,12 +208,12 @@ export class Crypto {
      * Generate random base64 string.
      * Note: Only available in Node.js environment.
      */
-    static randBase64(length: number): string {
+    static randBase64(length: number, randFill?: boolean): string {
         if (Crypto.isBrowser()) {
             Crypto.throwBrowserError('randBase64');
         }
 
-        const bytes = crypto.randomBytes(Math.ceil(length * 3 / 4));
+        const bytes = Crypto.randBytes(Math.ceil(length * 3 / 4), randFill);
         return bytes.toString('base64').substring(0, length);
     }
 
@@ -222,14 +223,15 @@ export class Crypto {
      * Note: Only available in Node.js environment.
      * 
      * @param length - Length of the base64 string to generate
+     * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
      * @returns Promise that resolves to a random base64 string
      */
-    static async randBase64Async(length: number): Promise<string> {
+    static async randBase64Async(length: number, randFill?: boolean): Promise<string> {
         if (Crypto.isBrowser()) {
             Crypto.throwBrowserError('randBase64Async');
         }
 
-        const bytes = await randomBytesAsync!(Math.ceil(length * 3 / 4));
+        const bytes = await Crypto.randBytesAsync!(Math.ceil(length * 3 / 4), randFill);
         return bytes.toString('base64').substring(0, length);
     }
 
@@ -1085,9 +1087,10 @@ export class Crypto {
      * dependency on the native crypto module for secure random number generation.
      * 
      * @param bits - The bit length of the bigint to generate (default: 1024)
+     * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
      * @returns A bigint with the specified bit length
      */
-    static randBigInt(bits: number = 1024): bigint {
+    static randBigInt(bits: number = 1024, randFill?: boolean): bigint {
         if (Crypto.isBrowser()) {
             Crypto.throwBrowserError('randBigInt');
         }
@@ -1099,7 +1102,7 @@ export class Crypto {
 
         // Calculate bytes needed (bits / 8, rounded up)
         const byteLength = Math.ceil(bits / 8);
-        const randomBytes = Crypto.randBytes(byteLength);
+        const randomBytes = Crypto.randBytes(byteLength, randFill);
 
         // Convert to bigint
         let num = BigInt('0x' + randomBytes.toString('hex'));
@@ -1124,9 +1127,10 @@ export class Crypto {
      * dependency on the native crypto module for secure random number generation.
      * 
      * @param bits - The bit length of the bigint to generate (default: 1024)
+     * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
      * @returns A Promise that resolves to a bigint with the specified bit length
      */
-    static async randBigIntAsync(bits: number = 1024): Promise<bigint> {
+    static async randBigIntAsync(bits: number = 1024, randFill?: boolean): Promise<bigint> {
         if (Crypto.isBrowser()) {
             Crypto.throwBrowserError('randBigIntAsync');
         }
@@ -1138,7 +1142,7 @@ export class Crypto {
 
         // Calculate bytes needed (bits / 8, rounded up)
         const byteLength = Math.ceil(bits / 8);
-        const randomBytes = await Crypto.randBytesAsync(byteLength);
+        const randomBytes = await Crypto.randBytesAsync(byteLength, randFill);
 
         // Convert to bigint
         let num = BigInt('0x' + randomBytes.toString('hex'));


### PR DESCRIPTION
- [+] Extend methods to accept an optional `randFill` parameter to toggle between `crypto.randomFill` and `crypto.randomBytes`.
- [+] Update documentation and comments to reflect the new `randFill` option.
- [+] Modify underlying logic to utilize the `randBytes` helper with `randFill` support.