### PR TITLE
Add `randFill` support to `randPrime`, `randPrimeAsync`, and related helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ async function generateRandomValues() {
 - `Crypto.randWalk(steps, stepSize?)` - Generate random walk sequence (stepSize defaults to 1)
 - `Crypto.randPassword(options)` - Generate secure password with configurable requirements
 - `Crypto.randLattice(dimension?, modulus?)` - Generate lattice-based cryptographically secure random number
-- `Crypto.randPrime(bits?, iterations?, enhanced?)` - Generate cryptographically secure random prime number with optional [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards)-enhanced mode
+- `Crypto.randPrime(bits?, iterations?, enhanced?, randFill?)` - Generate cryptographically secure random prime number with optional [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards)-enhanced mode
 - `Crypto.randSafePrime(bits?, iterations?, enhanced?)` - Generate cryptographically secure random safe prime number suitable for [Diffie-Hellman key exchanges](https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)
 - `Crypto.randBigInt(bits?, randFill?)` - Generate cryptographically secure random bigint with specified bit length
 - `Crypto.randExponential(lambda?)` - Generate random number with exponential distribution
@@ -146,7 +146,7 @@ async function generateRandomValues() {
 - `Crypto.randBase64Async(length, randFill?)` - Async version of randBase64()
 - `Crypto.randSeedAsync()` - Async version of randSeed()
 - `Crypto.randVersionAsync()` - Async version of randVersion()
-- `Crypto.randPrimeAsync(bits?, iterations?, enhanced?)` - Async version of randPrime() with optional [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards)-enhanced mode
+- `Crypto.randPrimeAsync(bits?, iterations?, enhanced?, randFill?)` - Async version of randPrime() with optional [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards)-enhanced mode
 - `Crypto.randSafePrimeAsync(bits?, iterations?, enhanced?)` - Async version of randSafePrime() for generating safe primes suitable for [Diffie-Hellman key exchanges](https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange)
 - `Crypto.randBigIntAsync(bits?, randFill?)` - Async version of randBigInt()
 

--- a/src/math_helper.ts
+++ b/src/math_helper.ts
@@ -16,18 +16,20 @@ import * as crypto from 'crypto';
  * @param k - The number of iterations for the test (a.k.a accuracy 🎯)
  * @param getRandomBytes - Function to generate random bytes (defaults to crypto.randomBytes)
  * @param enhanced - Whether to use the enhanced [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) version
+ * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
  * @returns A boolean indicating whether the number is probably prime
  */
 export function isProbablePrime(
     n: bigint,
     k: number,
-    getRandomBytes: (size: number) => Buffer | Uint8Array = crypto.randomBytes,
-    enhanced: boolean = false
+    getRandomBytes: (size: number, randFill?: boolean) => Buffer | Uint8Array = crypto.randomBytes,
+    enhanced: boolean = false,
+    randFill?: boolean
 ): boolean {
     if (enhanced) {
-        return isProbablePrimeEnhanced(n, k, getRandomBytes);
+        return isProbablePrimeEnhanced(n, k, getRandomBytes, randFill);
     } else {
-        return isProbablePrimeStandard(n, k, getRandomBytes);
+        return isProbablePrimeStandard(n, k, getRandomBytes, randFill);
     }
 }
 
@@ -40,12 +42,14 @@ export function isProbablePrime(
  * @param n - The number to test for primality
  * @param k - The number of iterations for the test (higher values increase accuracy)
  * @param getRandomBytes - Function to generate random bytes for witness selection
+ * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
  * @returns A boolean indicating whether the number is probably prime
  */
 function isProbablePrimeStandard(
     n: bigint,
     k: number,
-    getRandomBytes: (size: number) => Buffer | Uint8Array
+    getRandomBytes: (size: number, randFill?: boolean) => Buffer | Uint8Array,
+    randFill?: boolean
 ): boolean {
 
     // Handle small numbers
@@ -64,7 +68,7 @@ function isProbablePrimeStandard(
     // ⚙️ Witness loop
     for (let i = 0; i < k; i++) {
         // Generate a random integer a in the range [2, n-2]
-        const randomBytes = getRandomBytes(64); // 64 bytes should be enough for most primes
+        const randomBytes = getRandomBytes(64, randFill); // 64 bytes should be enough for most primes
         let a = BigInt('0x' + randomBytes.toString('hex')) % (n - 4n) + 2n;
 
         // Compute aᵈ mod n
@@ -99,12 +103,14 @@ function isProbablePrimeStandard(
  * @param n - The number to test for primality
  * @param k - The number of iterations for the test (higher values increase accuracy)
  * @param getRandomBytes - Function to generate random bytes for witness selection
+ * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
  * @returns A boolean indicating whether the number is probably prime according to [FIPS 186-5](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf) criteria
  */
 export function isProbablePrimeEnhanced(
     n: bigint,
     k: number,
-    getRandomBytes: (size: number) => Buffer | Uint8Array = crypto.randomBytes
+    getRandomBytes: (size: number, randFill?: boolean) => Buffer | Uint8Array,
+    randFill?: boolean
 ): boolean {
 
     // Handle small numbers
@@ -128,7 +134,7 @@ export function isProbablePrimeEnhanced(
         // Generate a random integer b in the range [2, n-2] (steps 4.1 and 4.2)
         let b: bigint;
         do {
-            const randomBytes = getRandomBytes(64); // 64 bytes should be enough for most primes
+            const randomBytes = getRandomBytes(64, randFill); // 64 bytes should be enough for most primes
             b = BigInt('0x' + randomBytes.toString('hex')) % (n - 1n);
         } while (b <= 1n || b >= n - 1n);
 
@@ -266,18 +272,20 @@ export function modInverse(a: bigint, m: bigint): bigint {
  * @param k - The number of iterations for the test (a.k.a accuracy 🎯)
  * @param getRandomBytesAsync - Async function to generate random bytes
  * @param enhanced - Whether to use the enhanced [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) version
+ * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
  * @returns A Promise that resolves to a boolean indicating whether the number is probably prime
  */
 export async function isProbablePrimeAsync(
     n: bigint,
     k: number,
     getRandomBytesAsync: (size: number) => Promise<Buffer | Uint8Array>,
-    enhanced: boolean = false
+    enhanced: boolean = false,
+    randFill?: boolean
 ): Promise<boolean> {
     if (enhanced) {
-        return isProbablePrimeEnhancedAsync(n, k, getRandomBytesAsync);
+        return isProbablePrimeEnhancedAsync(n, k, getRandomBytesAsync, randFill);
     } else {
-        return isProbablePrimeStandardAsync(n, k, getRandomBytesAsync);
+        return isProbablePrimeStandardAsync(n, k, getRandomBytesAsync, randFill);
     }
 }
 
@@ -291,12 +299,14 @@ export async function isProbablePrimeAsync(
  * @param n - The number to test for primality
  * @param k - The number of iterations for the test (higher values increase accuracy)
  * @param getRandomBytesAsync - Async function to generate random bytes for witness selection
+ * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
  * @returns A Promise that resolves to a boolean indicating whether the number is probably prime
  */
 async function isProbablePrimeStandardAsync(
     n: bigint,
     k: number,
-    getRandomBytesAsync: (size: number) => Promise<Buffer | Uint8Array>
+    getRandomBytesAsync: (size: number, randFill?: boolean) => Promise<Buffer | Uint8Array>,
+    randFill?: boolean
 ): Promise<boolean> {
 
     // Handle small numbers
@@ -315,7 +325,7 @@ async function isProbablePrimeStandardAsync(
     // ⚙️ Witness loop
     for (let i = 0; i < k; i++) {
         // Generate a random integer a in the range [2, n-2]
-        const randomBytes = await getRandomBytesAsync(64); // 64 bytes should be enough for most primes
+        const randomBytes = await getRandomBytesAsync(64, randFill); // 64 bytes should be enough for most primes
         let a = BigInt('0x' + randomBytes.toString('hex')) % (n - 4n) + 2n;
 
         // Compute aᵈ mod n
@@ -351,12 +361,14 @@ async function isProbablePrimeStandardAsync(
  * @param n - The number to test for primality
  * @param k - The number of iterations for the test (higher values increase accuracy)
  * @param getRandomBytesAsync - Async function to generate random bytes for witness selection
+ * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
  * @returns A Promise that resolves to a boolean indicating whether the number is probably prime according to [FIPS 186-5](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf) criteria
  */
 export async function isProbablePrimeEnhancedAsync(
     n: bigint,
     k: number,
-    getRandomBytesAsync: (size: number) => Promise<Buffer | Uint8Array>
+    getRandomBytesAsync: (size: number, randFill?: boolean) => Promise<Buffer | Uint8Array>,
+    randFill?: boolean
 ): Promise<boolean> {
 
     // Handle small numbers
@@ -380,7 +392,7 @@ export async function isProbablePrimeEnhancedAsync(
         // Generate a random integer b in the range [2, n-2] (steps 4.1 and 4.2)
         let b: bigint;
         do {
-            const randomBytes = await getRandomBytesAsync(64); // 64 bytes should be enough for most primes
+            const randomBytes = await getRandomBytesAsync(64, randFill); // 64 bytes should be enough for most primes
             b = BigInt('0x' + randomBytes.toString('hex')) % (n - 1n);
         } while (b <= 1n || b >= n - 1n);
 

--- a/src/rand.ts
+++ b/src/rand.ts
@@ -257,7 +257,7 @@ export class Crypto {
             return array;
         } else if (typeof crypto !== 'undefined' && crypto.randomBytes) {
             // Node.js environment
-            if (randFill && typeof crypto.randomFillSync === 'function') {
+            if (randFill === true && typeof crypto.randomFillSync === 'function') {
                 // Use crypto.randomFill when requested
                 // Note: Buffer.allocUnsafe is safe here because the entire buffer
                 // is immediately filled with cryptographically secure random data,
@@ -291,7 +291,7 @@ export class Crypto {
             return array;
         } else if (typeof crypto !== 'undefined' && randomBytesAsync) {
             // Node.js environment
-            if (randFill && randomFillAsync) {
+            if (randFill === true && randomFillAsync) {
                 // Use crypto.randomFill when requested
                 // Note: Buffer.allocUnsafe is safe here because the entire buffer
                 // is immediately filled with cryptographically secure random data,
@@ -764,12 +764,14 @@ export class Crypto {
      * @param bits - The bit length of the prime number to generate (default: 1024)
      * @param iterations - The number of iterations for the [Miller-Rabin primality test](https://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test) (a.k.a accuracy 🎯, default: 10)
      * @param enhanced - Whether to use the enhanced [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) version (default: false)
+     * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
      * @returns A bigint representing a probable prime number of the specified bit length
      */
     static randPrime(
         bits: number = 1024,
         iterations: number = 10,
         enhanced: boolean = false,
+        randFill?: boolean,
     ): bigint {
         if (Crypto.isBrowser()) {
             Crypto.throwBrowserError('randPrime');
@@ -793,7 +795,7 @@ export class Crypto {
         // 4. The statistical distribution of the search process is independent of the specific prime value
         let candidate: bigint;
         do {
-            candidate = Crypto.randBigInt(bits);
+            candidate = Crypto.randBigInt(bits, randFill);
         } while (!isProbablePrime(candidate, iterations, Crypto.randBytes, enhanced));
 
         return candidate;
@@ -812,12 +814,14 @@ export class Crypto {
      * @param bits - The bit length of the prime number to generate (default: 1024)
      * @param iterations - The number of iterations for the [Miller-Rabin primality test](https://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test) (a.k.a accuracy 🎯, default: 10)
      * @param enhanced - Whether to use the enhanced [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) version (default: false)
+     * @param randFill - Optional parameter to use [crypto.randomFill](https://nodejs.org/api/crypto.html#cryptorandomfillbuffer-offset-size-callback) instead of [crypto.randomBytes](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) (Node.js only)
      * @returns A Promise that resolves to a bigint representing a probable prime number of the specified bit length
      */
     static async randPrimeAsync(
         bits: number = 1024,
         iterations: number = 10,
         enhanced: boolean = false,
+        randFill?: boolean,
     ): Promise<bigint> {
         if (Crypto.isBrowser()) {
             Crypto.throwBrowserError('randPrimeAsync');
@@ -842,7 +846,7 @@ export class Crypto {
         let candidate: bigint, isPrime: boolean;
 
         do {
-            candidate = await Crypto.randBigIntAsync(bits);
+            candidate = await Crypto.randBigIntAsync(bits, randFill);
             isPrime = await isProbablePrimeAsync(candidate, iterations, Crypto.randBytesAsync, enhanced);
         } while (!isPrime);
 

--- a/tests/crypto.async.test.ts
+++ b/tests/crypto.async.test.ts
@@ -578,7 +578,7 @@ describe('Crypto Async Methods', () => {
 
     it('should generate a number with the correct bit length', async () => {
       const bits = 32;
-      const bigint = await randBigIntAsync(bits);
+      const bigint = await randBigIntAsync(bits, true);
 
       // Check bit length
       const bitLength = bigint.toString(2).length;

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -3229,7 +3229,7 @@ describe('Crypto Class', () => {
 
     describe('basic functionality', () => {
       test('should return a BigInt', () => {
-        const result = Crypto.randBigInt(32); // Small bit size for faster tests
+        const result = Crypto.randBigInt(32, true); // Small bit size for faster tests
         expect(typeof result).toBe('bigint');
       });
 
@@ -3319,11 +3319,11 @@ describe('Crypto Class', () => {
         Crypto.randBigInt = jest.fn().mockImplementation(originalRandBigInt);
 
         // Call randPrime which should use randBigInt
-        Crypto.randPrime(32, 5);
+        Crypto.randPrime(32, 5, false, true);
 
         // Verify randBigInt was called
         expect(Crypto.randBigInt).toHaveBeenCalled();
-        expect(Crypto.randBigInt).toHaveBeenCalledWith(32);
+        expect(Crypto.randBigInt).toHaveBeenCalledWith(32, true);
 
         // Restore original method
         Crypto.randBigInt = originalRandBigInt;


### PR DESCRIPTION
- [+] Extend `randPrime` and `randPrimeAsync` methods to accept an optional `randFill` parameter.
- [+] Update documentation, tests, and comments for `randFill` usage in both sync and async prime generation.
- [+] Refactor `isProbablePrime` (sync/async) methods to include `randFill` parameter for optimized random byte generation.